### PR TITLE
Iterate polyfills instead of calling each individually

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ const polyfills = [
   aggregateError,
   arrayAt,
   cryptoRandomUUID,
-  elementReplaceChildren
+  elementReplaceChildren,
   eventAbortSignal,
   objectHasOwn,
   promiseAny,


### PR DESCRIPTION
While reviewing #4, I noticed we are repeating these function calls for each polyfill.  If we put all the polyfills in an array and iterate, we can achieve the same goal with a lot less code.  It also helps avoid accidentally adding a new polyfill to one of these functions while missing one of the others

This takes the `lib/index.js` from 2,855 bytes to 2,311 bytes. Roughly .5kB before minification/gzip isn't a _ton_, but it's something 😄 
