### PR TITLE
Improve User Agent parsing

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -49,15 +49,19 @@
     <script type="module" defer>
       import {isSupported, isPolyfilled, baseSupport, apply, polyfills} from '../lib/index.js'
       // import {isSupported, isPolyfilled, apply, poyfills} from 'https://unpkg.com/@github/browser-support@latest/lib/index.js'
-      let browser
-      let version
-      for(const term of navigator.userAgent.split(' ')) {
-        if (term.indexOf('/') !== -1) {
-          browser = term.split('/')[0]
-          version = term.split('/')[1]
-          if (browser === 'Chrome') break
+      function getBrowser(useragent) {
+        if ('userAgentData' in navigator) {
+          const {brand, version} = Array.from(navigator.userAgentData.brands).pop()
+          return [brand, version]
         }
+        const parts = useragent.split(' ')
+        let [name, version] = parts.pop().split('/')
+        if (name === 'Safari') {
+          version = parts.pop().split('/').pop()
+        }
+        return [name, version]
       }
+      const [browser, version] = getBrowser(navigator.userAgent)
       document.getElementById('your-browser').innerText = browser + " " + version
       for(const el of document.querySelectorAll('[data-code]')) {
         let supported = false


### PR DESCRIPTION
Used `navigator.userAgentData` when available to circumvent parsing the User Agent String.

I'm not sure how much of older browsers we want to cover since it can get hard very quickly.