### PR TITLE
remove asterisks for export tests

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -855,6 +855,7 @@
         }
         Promise.resolve(supported).then((value) => {
           el.setAttribute('data-supported', Boolean(value))
+          if (value) el.querySelector('div').textContent = ''
         })
       }
       for(const el of document.querySelectorAll('[data-polyfill]')) {


### PR DESCRIPTION
Polyfill checks still show asterisks even when the feature test passes. This adds the code to make sure the asterisk is removed.
 
![a screenshot of the current page showing asterisks for passing tests](https://user-images.githubusercontent.com/118266/162731542-09ce69fe-92e5-4564-9342-0a780efc37a9.png)
