### PR TITLE
add firefox support for abortsignal timeout

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -483,14 +483,14 @@
           </tr>
           <tr>
             <th>
-              <a href="https://chromestatus.com/feature/5768400507764736">
+              <a href="https://developer.mozilla.org/docs/Web/API/AbortSignal/timeout">
                 <code>AbortSignal.timeout</code>
               </a>
             </th>
             <td data-polyfill="abortSignalTimeout"><div>*</div></td>
             <td data-supported="false"><div>*</div></td>
             <td data-supported="false"><div>*</div></td>
-            <td data-supported="false"><div>*</div></td>
+            <td data-supported="true"><div>100+</div></td>
             <td data-supported="false"><div>*</div></td>
             <td data-supported="false"><div>*</div></td>
             <td data-supported="false"><div>*</div></td>


### PR DESCRIPTION
Firefox 100 introduced `AbortSignal.timeout`. This changes our support table to reflect that!