### PR TITLE
Move optional chaining and nullish coalescing operators to native syntax section

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -720,7 +720,6 @@
             <td data-supported="true"><div>53+</div></td>
             <td data-supported="true"><div>9.0+</div></td>
           </tr>
-          <tr data-transpiled><th></th><th colspan="7"><h3>Transpiled Native Syntax</h3></th></tr>
           <tr>
             <th>
               <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining">
@@ -749,6 +748,7 @@
             <td data-supported="true"><div>67+</div></td>
             <td data-supported="true"><div>13.0+</div></td>
           </tr>
+          <tr data-transpiled><th></th><th colspan="7"><h3>Transpiled Native Syntax</h3></th></tr>
           <tr>
             <th>
               <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_nullish_assignment">


### PR DESCRIPTION
In preparation for us not transpiling the optional chaining and bullish coalescing operators in github.com. We can merge this PR right after deploying that change to dotcom.

See https://github.blog/2022-06-10-how-we-think-about-browsers/