### PR TITLE
Fix `every` calls to return values

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -72,16 +72,12 @@ export const polyfills = {
 export function isSupported() {
   return (
     baseSupport &&
-    Object.values(polyfills).every(polyfill => {
-      polyfill.isSupported()
-    })
+    Object.values(polyfills).every(polyfill => polyfill.isSupported())
   )
 }
 
 export function isPolyfilled() {
-  return Object.values(polyfills).every(polyfill => {
-    polyfill.isPolyfilled()
-  })
+  return Object.values(polyfills).every(polyfill => polyfill.isPolyfilled())
 }
 
 export function apply() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,10 +70,7 @@ export const polyfills = {
 }
 
 export function isSupported() {
-  return (
-    baseSupport &&
-    Object.values(polyfills).every(polyfill => polyfill.isSupported())
-  )
+  return baseSupport && Object.values(polyfills).every(polyfill => polyfill.isSupported())
 }
 
 export function isPolyfilled() {


### PR DESCRIPTION
`isSupported` and  `isPolyfilled` were always returning false, since `.every` requires the callback to return the value being checked