### PR TITLE
check existence of clipboard in navigator

### DIFF
--- a/src/navigator-clipboard.ts
+++ b/src/navigator-clipboard.ts
@@ -11,15 +11,15 @@ export async function clipboardRead() {
 }
 
 export function isSupported(): boolean {
-  return typeof navigator.clipboard.read === 'function' && typeof navigator.clipboard.write === 'function'
+  return 'clipboard' in navigator && typeof navigator.clipboard.read === 'function' && typeof navigator.clipboard.write === 'function'
 }
 
 export function isPolyfilled(): boolean {
-  return navigator.clipboard.write === clipboardWrite || navigator.clipboard.read === clipboardRead
+  return 'clipboard' in navigator && (navigator.clipboard.write === clipboardWrite || navigator.clipboard.read === clipboardRead)
 }
 
 export function apply(): void {
-  if (!isSupported()) {
+  if ('clipboard' in navigator && !isSupported()) {
     navigator.clipboard.write = clipboardWrite
     navigator.clipboard.read = clipboardRead
   }

--- a/src/navigator-clipboard.ts
+++ b/src/navigator-clipboard.ts
@@ -11,11 +11,18 @@ export async function clipboardRead() {
 }
 
 export function isSupported(): boolean {
-  return 'clipboard' in navigator && typeof navigator.clipboard.read === 'function' && typeof navigator.clipboard.write === 'function'
+  return (
+    'clipboard' in navigator &&
+    typeof navigator.clipboard.read === 'function' &&
+    typeof navigator.clipboard.write === 'function'
+  )
 }
 
 export function isPolyfilled(): boolean {
-  return 'clipboard' in navigator && (navigator.clipboard.write === clipboardWrite || navigator.clipboard.read === clipboardRead)
+  return (
+    'clipboard' in navigator &&
+    (navigator.clipboard.write === clipboardWrite || navigator.clipboard.read === clipboardRead)
+  )
 }
 
 export function apply(): void {


### PR DESCRIPTION
This fixes an issue I have encountered recently in Github webpage in my web browser, where `clipboard` is not defined in `navigator`. I believe its presence should be checked before touching its items in similar fashion like other `isSupported` methods do. This PR is related to #18.