### PR TITLE
Update ci to use node 18

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,15 +5,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js 16.x
-      uses: actions/setup-node@v1
-      with:
-        node-version: 16.x
-    - name: npm install, build, and test
-      run: |
-        npm install
-        npm run build
-        npm test
-      env:
-        CI: true
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: https://registry.npmjs.org/
+          cache: npm
+      - run: npm ci
+      - run: npm test
+        env:
+          CI: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 18
           registry-url: https://registry.npmjs.org/
           cache: npm
       - run: npm ci


### PR DESCRIPTION
The publish npm action is [failing](https://github.com/github/browser-support/actions/runs/5365072880/jobs/9809294853) currently. I'd like to try updating node to see if that solves the issue.

I also updated the standard nodejs workflow to match more closely with the publish workflow