### PR TITLE
move class fields & logical assignment to native syntax

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -869,10 +869,6 @@
             <td data-supported="true"><div>67+</div></td>
             <td data-supported="true"><div>13.0+</div></td>
           </tr>
-          <tr data-transpiled>
-            <th></th>
-            <th colspan="7"><h3>Transpiled Native Syntax</h3></th>
-          </tr>
           <tr>
             <th>
               <a
@@ -934,6 +930,10 @@
             <td data-supported="true"><div>16.4+</div></td>
             <td data-supported="true"><div>80+</div></td>
             <td data-supported="true"><div>17.0+</div></td>
+          </tr>
+          <tr data-transpiled>
+            <th></th>
+            <th colspan="7"><h3>Transpiled Native Syntax</h3></th>
           </tr>
           <tr>
             <th>


### PR DESCRIPTION
With the move to swc we should properly reflect that public/private class fields, static blocks, and the nullish coalescing operator are all being shipped untranspiled.

Closes https://github.com/github/github/issues/295698 

This probably should have been changed as part of [2.0](https://github.com/github/browser-support/releases/tag/v2.0.0).