### PR TITLE
Include :modal selector in base support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,12 @@ import * as elementCheckVisibility from './element-checkvisibility.js'
 import * as navigatorClipboard from './navigator-clipboard.js'
 import * as requestIdleCallback from './requestidlecallback.js'
 
+let supportsModalPseudo = false
+try {
+  // This will error in older browsers
+  supportsModalPseudo = document.body.matches(':modal') === false
+} catch {}
+
 export const baseSupport =
   typeof globalThis === 'object' &&
   // ES2019
@@ -26,6 +32,7 @@ export const baseSupport =
   // DOM / HTML and other specs
   typeof queueMicrotask === 'function' &&
   typeof HTMLDialogElement === 'function' &&
+  supportsModalPseudo &&
   typeof AggregateError === 'function' &&
   typeof BroadcastChannel === 'function' &&
   'randomUUID' in crypto &&

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,9 @@ let supportsModalPseudo = false
 try {
   // This will error in older browsers
   supportsModalPseudo = document.body.matches(':modal') === false
-} catch {}
+} catch {
+  supportsModalPseudo = false
+}
 
 export const baseSupport =
   typeof globalThis === 'object' &&


### PR DESCRIPTION
We've noticed errors from browsers which do not support `:modal` as a pseudo selector. We should discount these errors from our reporting as our support matrix encompasses browsers which _do_ support `:modal`.