### PR TITLE
update HTMLDialogElement constructor versions for Opera/Safari

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -217,8 +217,8 @@
             <td data-supported="true"><div>37+</div></td>
             <td data-supported="true"><div>79+</div></td>
             <td data-supported="true"><div>98+</div></td>
-            <td data-supported="true"><div>24+</div></td>
             <td data-supported="true"><div>15.4+</div></td>
+            <td data-supported="true"><div>24+</div></td>
             <td data-supported="true"><div>4.0+</div></td>
           </tr>
           <tr>


### PR DESCRIPTION
Hi, just came across this table via your [engineering blog](https://github.blog/engineering/infrastructure/how-we-think-about-browsers/), looks like these versions just got switched around?

Before

<img width="1919" alt="Screenshot 2024-10-06 at 10 30 15 am" src="https://github.com/user-attachments/assets/50e1b56d-1de7-4eae-8c39-ba5ce88a5fd1">

After

<img width="1919" alt="Screenshot 2024-10-06 at 10 58 18 am" src="https://github.com/user-attachments/assets/77988fd2-f86f-42e0-ab4a-c7a7aa8eb149">

[HTMLDialogElement Constructor](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement)

