### PR TITLE
requestIdleTimer might be 50

### DIFF
--- a/test/requestidlecallback.js
+++ b/test/requestidlecallback.js
@@ -14,6 +14,6 @@ describe('requestIdleCallback', () => {
     expect(Object.keys(arg)).to.eql(['didTimeout', 'timeRemaining'])
     expect(arg).to.have.property('didTimeout').to.be.a('boolean')
     expect(arg).to.have.property('timeRemaining').to.be.a('function')
-    expect(arg.timeRemaining()).to.be.a('number').lessThan(50).greaterThanOrEqual(0)
+    expect(arg.timeRemaining()).to.be.a('number').lessThanOrEqual(50).greaterThanOrEqual(0)
   })
 })


### PR DESCRIPTION
This test flakes because the timeout can be 50 exactly, but the test expects less than 50 only