### PR TITLE
add dialog-toggle-events polyfill

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -574,6 +574,20 @@
             <td data-supported="true"><div>12.0+</div></td>
           </tr>
           <tr>
+            <th>
+              <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/beforetoggle_event">
+                <code>beforetoggle on Dialog</code>
+              </a>
+            </th>
+            <td data-polyfill="dialogToggleEvents"><div>*</div></td>
+            <td data-supported="true"><div>132+</div></td>
+            <td data-supported="true"><div>132+</div></td>
+            <td data-supported="true"><div>133+</div></td>
+            <td data-supported="false"><div>*</div></td>
+            <td data-supported="true"><div>117+</div></td>
+            <td data-supported="true"><div>*</div></td>
+          </tr>
+          <tr>
             <th></th>
             <th colspan="7"><h3>Native Syntax</h3></th>
           </tr>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
             "version": "1.2.2",
             "license": "MIT",
             "dependencies": {
-                "@oddbird/popover-polyfill": "^0.5.2"
+                "@oddbird/popover-polyfill": "^0.5.2",
+                "dialog-toggle-events-polyfill": "^1.1.2"
             },
             "devDependencies": {
                 "@github/prettier-config": "^0.0.6",
@@ -3226,6 +3227,12 @@
             "integrity": "sha512-JwAYQgEvm3yD45CHB+RmF5kMbWtXBaOGwuxa87sZogHcLCv8c/IqnThaoQ1y60d7pXWjSKWQphPEc+1rAScVdg==",
             "dev": true,
             "license": "BSD-3-Clause"
+        },
+        "node_modules/dialog-toggle-events-polyfill": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/dialog-toggle-events-polyfill/-/dialog-toggle-events-polyfill-1.1.2.tgz",
+            "integrity": "sha512-0XLpm2dfUg2NH0YRp2DkP3XkJqlM7k0Jx5sH+O/llAazxYirbdI+lqW7dgtzUnAFmQL0deo0yoeNln7gPEclRw==",
+            "license": "MIT"
         },
         "node_modules/diff": {
             "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
         "typescript": "^5.2.2"
     },
     "dependencies": {
-        "@oddbird/popover-polyfill": "^0.5.2"
+        "@oddbird/popover-polyfill": "^0.5.2",
+        "dialog-toggle-events-polyfill": "^1.1.2"
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import * as navigatorClipboard from './navigator-clipboard.js'
 import * as withResolvers from './promise-withResolvers.js'
 import * as requestIdleCallback from './requestidlecallback.js'
 import * as popover from '@oddbird/popover-polyfill/fn'
+import * as dialogToggleEvents from 'dialog-toggle-events-polyfill/fn'
 
 let supportsModalPseudo = false
 try {
@@ -51,6 +52,7 @@ export const polyfills = {
   requestIdleCallback,
   withResolvers,
   popover,
+  dialogToggleEvents,
 }
 
 export function isSupported() {


### PR DESCRIPTION
In https://github.com/primer/view_components/pull/3332 we're pulling in a dialog-toggle-events-polyfill. Ideally, however, all polyfills should be part of this library.

This PR introduces the same dialog-toggle-events-polyfill to this library, so that other downstream libraries like Primer may use it.