### PR TITLE
Build on publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,7 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org/
           cache: npm
+      - run: npm run build
       - run: npm ci
       - run: npm test
       - run: npm version ${TAG_NAME} --git-tag-version=false


### PR DESCRIPTION
In https://github.com/github/browser-support/pull/75 we switched from karma to wtr; and as part of that the `test` & `pretest` scripts changed:

```diff
- "pretest": "npm run build",
+ "pretest": "npm run lint && npm run check",
- "test": "npm run lint && karma start test/karma.config.cjs",
+ "test": "wtr",
```

We switched from _needing_ to build the package to run tests, to instead using `wtr`'s ability to transpile typescript just in time. This results in faster tests, as there's less work to do beforehand, and so we can confidently drop the `npm run build` pretest script.

However, our publish pipeline _incidentally relied_ on build being implicitly run. Consequently, when we released `4.2.0` it doesn't include `lib` like it's supposed to, rendering the package unusable. 

This PR adds `npm run build` back into the publish pipeline as an _explicit step_, so that `lib` is included in the package again. We should release this as `4.2.1`.