### PR TITLE
Apply polyfills only when unsupported

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,6 @@ export function isPolyfilled() {
 
 export function apply() {
   for (const polyfill of Object.values(polyfills)) {
-    polyfill.apply()
+    if (!polyfill.isSupported()) polyfill.apply()
   }
 }


### PR DESCRIPTION
Polyfills which have an `apply()` method may sometimes unconditionally polyfill code. This propagates up to our main `apply()` function, which is not ideal.

Instead the `apply()` function should only apply polyfills that are needed. This PR changes this to ensure that polyfills are only applied when they are unsupported.