### PR TITLE
Override Koa version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5409,9 +5409,9 @@
             }
         },
         "node_modules/koa": {
-            "version": "2.16.1",
-            "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.1.tgz",
-            "integrity": "sha512-umfX9d3iuSxTQP4pnzLOz0HKnPg0FaUUIKcye2lOiz3KPu1Y3M3xlz76dISdFPQs37P9eJz1wUpcTS6KDPn9fA==",
+            "version": "2.16.2",
+            "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.2.tgz",
+            "integrity": "sha512-+CCssgnrWKx9aI3OeZwroa/ckG4JICxvIFnSiOUyl2Uv+UTI+xIw0FfFrWS7cQFpoePpr9o8csss7KzsTzNL8Q==",
             "dev": true,
             "dependencies": {
                 "accepts": "^1.3.5",

--- a/package.json
+++ b/package.json
@@ -48,5 +48,8 @@
     "dependencies": {
         "@oddbird/popover-polyfill": "^0.5.2",
         "invokers-polyfill": "^0.5.2"
+    },
+    "overrides": {
+        "koa": "2.16.2"
     }
 }


### PR DESCRIPTION
### What approach did you choose and why?

We are implementing an override to use version `2.16.2` of the `koa` npm package to address the following security vulnerability: https://github.com/github/browser-support/security/dependabot/38.

This approach is recommended because koa is a transitive dependency, and some dependencies continue to use the vulnerable version. Overriding ensures our project uses a secure version until upstream dependencies are updated.

Verified that we are using the correct `koa` version after the update:
```
 npm ls koa
@github/browser-support@1.2.2 /workspaces/browser-support
└─┬ @web/dev-server-esbuild@1.0.4
  └─┬ @web/dev-server-core@0.7.5
    └── koa@2.16.2 overridden
```