### PR TITLE
Supply chain improvements

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,10 +9,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22
+          node-version: 26
           registry-url: https://registry.npmjs.org/
           cache: npm
       - run: npm ci

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,10 +11,10 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '24'
+          node-version: '26'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run build

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=3

--- a/package-lock.json
+++ b/package-lock.json
@@ -2422,9 +2422,9 @@
             }
         },
         "node_modules/basic-ftp": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-            "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+            "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4965,15 +4965,11 @@
             "license": "MIT"
         },
         "node_modules/ip-address": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-            "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+            "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "jsbn": "1.1.0",
-                "sprintf-js": "^1.1.3"
-            },
             "engines": {
                 "node": ">= 12"
             }
@@ -5435,13 +5431,6 @@
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
             }
-        },
-        "node_modules/jsbn": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-            "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
@@ -6509,9 +6498,9 @@
             }
         },
         "node_modules/puppeteer-core/node_modules/ws": {
-            "version": "8.18.1",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
-            "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6531,9 +6520,9 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-            "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+            "version": "6.15.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+            "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -7205,13 +7194,13 @@
             }
         },
         "node_modules/socks": {
-            "version": "2.8.4",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
-            "integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
+            "version": "2.8.9",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+            "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "ip-address": "^9.0.5",
+                "ip-address": "^10.1.1",
                 "smart-buffer": "^4.2.0"
             },
             "engines": {
@@ -7243,13 +7232,6 @@
             "engines": {
                 "node": ">= 8"
             }
-        },
-        "node_modules/sprintf-js": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-            "dev": true,
-            "license": "BSD-3-Clause"
         },
         "node_modules/statuses": {
             "version": "1.5.0",


### PR DESCRIPTION
## Summary
- update CI and publish automation to current pinned GitHub Actions and Node 26
- add the requested npm release-age policy and refresh the lockfile with `npm audit fix`

## What changed
- added project-level `.npmrc` with `min-release-age=3`
- updated `actions/checkout` to `v6.0.3` and `actions/setup-node` to `v6.4.0`, pinned to full SHAs
- moved the main CI workflow from Node 22 to Node 26
- moved the publish workflow from Node 24 to Node 26
- kept `npm ci` in CI and publish workflows
- kept npm publishing on OIDC trusted publishing; this repo was already using `npm publish --provenance` with `id-token: write` and no `NODE_AUTH_TOKEN`
- ran `npm audit fix` and refreshed `package-lock.json`

## Files changed
- `.npmrc`
- `.github/workflows/nodejs.yml`
- `.github/workflows/publish.yml`
- `package-lock.json`

## Ecosystems detected
- npm
- GitHub Actions

## Applied recommendations
- deterministic npm installs in CI via `npm ci`
- install-time npm release-age controls via `.npmrc`
- pinned third-party GitHub Actions to full SHAs and updated stale action versions
- Node 26 used in CI and publish automation
- OIDC-based npm publishing retained
- audit fixes applied with checks passing afterward

## Could not be applied automatically
- none

## Human review notes
- no `pull_request_target` workflows were found
- workflow permissions remain narrow: `contents: read` in CI and `contents: read` plus `id-token: write` for publish
- `npm` 11 emits a warning that `min-release-age` is an unknown project config in this environment, even though installs/build/tests continue to pass

## Validation
- `npm install`
- `npm ci`
- `npm run build`
- `CI=1 npm test`
- `npm audit` (0 vulnerabilities)