### PR TITLE
Run npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2492,9 +2492,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {


### PR DESCRIPTION
Ran `npm audit fix` to pick up patched transitive dependencies.

Resolves:
- `brace-expansion` — [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp), [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg), [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895)

Only `package-lock.json` changed — no direct dependency versions were bumped. `npm audit` now reports **0 vulnerabilities**.

### Validation
- `npm test` passes (lint + `tsc --noEmit` + 79 tests across 11 files)